### PR TITLE
Fix MySQL check if PDNSCONF_GMYSQL_HOST is not "mysql".

### DIFF
--- a/pdns/start.sh
+++ b/pdns/start.sh
@@ -5,6 +5,8 @@ mkdir -p /etc/powerdns/pdns.d
 PDNSVARS=`echo ${!PDNSCONF_*}`
 touch /etc/powerdns/pdns.conf
 
+PDNSCONF_GMYSQL_HOST=${PDNSCONF_GMYSQL_HOST:-mysql}
+
 if [ ! -z $MYSQL_ENV_MARIADB_DATABASE ]; then
    PDNSCONF_GMYSQL_USER=$MYSQL_ENV_MARIADB_USER 
    PDNSCONF_GMYSQL_DBNAME=$MYSQL_ENV_MARIADB_DATABASE 
@@ -35,7 +37,7 @@ fi
 mysqlcheck() {
   # Wait for MySQL to be available...
   COUNTER=20
-  until mysql -h mysql -u $PDNSCONF_GMYSQL_USER -p$PDNSCONF_GMYSQL_PASSWORD -e "show databases" 2>/dev/null; do
+  until mysql -h "$PDNSCONF_GMYSQL_HOST" -u "$PDNSCONF_GMYSQL_USER" -p"$PDNSCONF_GMYSQL_PASSWORD" -e "show databases" 2>/dev/null; do
     echo "WARNING: MySQL still not up. Trying again..."
     sleep 10
     let COUNTER-=1
@@ -45,10 +47,10 @@ mysqlcheck() {
     fi
   done
 
-  count=`mysql -h mysql -u $PDNSCONF_GMYSQL_USER -p$PDNSCONF_GMYSQL_PASSWORD -e "select count(*) from information_schema.tables where table_type='BASE TABLE' and table_schema='$PDNSCONF_GMYSQL_DBNAME';" | tail -1`
+  count=`mysql -h "$PDNSCONF_GMYSQL_HOST" -u "$PDNSCONF_GMYSQL_USER" -p"$PDNSCONF_GMYSQL_PASSWORD" -e "select count(*) from information_schema.tables where table_type='BASE TABLE' and table_schema='$PDNSCONF_GMYSQL_DBNAME';" | tail -1`
   if [ "$count" == "0" ]; then
     echo "Database is empty. Importing PowerDNS schema..."
-    mysql -h mysql -u $PDNSCONF_GMYSQL_USER -p$PDNSCONF_GMYSQL_PASSWORD $PDNSCONF_GMYSQL_DBNAME < /usr/share/doc/pdns-backend-mysql/schema.mysql.sql && echo "Import done."
+    mysql -h "$PDNSCONF_GMYSQL_HOST" -u "$PDNSCONF_GMYSQL_USER" -p"$PDNSCONF_GMYSQL_PASSWORD" "$PDNSCONF_GMYSQL_DBNAME" < /usr/share/doc/pdns-backend-mysql/schema.mysql.sql && echo "Import done."
   fi
 }
 


### PR DESCRIPTION
Fixes interlegis/docker-powerdns#3.

Specifically, this will allow users to supply `PDNSCONF_GMYSQL_HOST` as environment variable and the script will pick it up instead of using `mysql` as hardcoded hostname for checking whether the database is available.